### PR TITLE
Apply fix to Z-axis color filling in 3D graphs.

### DIFF
--- a/Graph/pie.pm
+++ b/Graph/pie.pm
@@ -244,6 +244,7 @@ sub draw_data
 
     for (my $i = 0; $i < @values; $i++)
     {
+        next unless $values[$i];
         # Set the data colour
         my $dc = $self->set_clr_uniq($self->pick_data_clr($i + 1));
 
@@ -355,7 +356,7 @@ sub _get_pie_front_coords # (angle 1, angle 2)
             # Ah, but if this wraps all the way around the back
             # then both pieces of the front need to be filled.
             # sbonds.
-            if ($pa > $pb ) 
+            if ($pa >= $pb ) 
             {
                 # This takes care of the left bit on the front
                 # Since we know exactly where we are, and in which
@@ -391,9 +392,8 @@ sub _get_pie_front_coords # (angle 1, angle 2)
         }
         elsif ( # both in back, but wrapping around the front
                 # CONTRIB kedlubnowski, Dan Rosendorf 
-            $pa > 90 && $pb > 90 && $pa >= $pb
-            or $pa < -90 && $pb < -90 && $pa >= $pb
-            or $pa < -90 && $pb > 90
+            $pa >= $pb && ($pa < 0 || $pb > 0)
+            or $pa < 0 && $pb > 0
         ) 
         {   
             $pa=$ANGLE_OFFSET - 180;


### PR DESCRIPTION
This applies the patch from Debian Bug #489184 (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=489184)
against the latest version of GD-Graph. By running the pietest script found in the Debian bug I was able
to confirm this is still a current issue in GD-Graph 1.48, and that this patch still fixes it.