### PR TITLE
Bump ExtUtils::MakeMaker dependency to support arrayref AUTHORS

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,7 +3,7 @@
  
 #--- Distribution section ---
  
-use ExtUtils::MakeMaker;
+use ExtUtils::MakeMaker 6.57_02;
 use Config;
  
 #use ExtUtils::Manifest;
@@ -27,6 +27,12 @@ WriteMakefile(
             ):()
         ),
 
+        BUILD_REQUIRES   => {
+            'ExtUtils::MakeMaker' => 6.57_02,
+        },
+        CONFIGURE_REQUIRES   => {
+            'ExtUtils::MakeMaker' => 6.57_02,
+        },
         'PREREQ_PM'     => { 
             'GD'	    => '1.18', 
             'GD::Text'      => '0.80',


### PR DESCRIPTION
This prevents the arcane error:
    only nested arrays of non-refs are supported at ...

when installing on RHEL/CentOS 6, which ships with an old
ExtUtils::MakeMaker.